### PR TITLE
nested keys (tests & fix)

### DIFF
--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -19,3 +19,4 @@ pytest-doctestplus==0.4.0
 pytest-remotedata==0.3.2
 h5py==2.10.0
 s3fs==0.3.4; python_version > '3.0'
+moto==1.3.14

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -981,7 +981,9 @@ class FSStore(MutableMapping):
         key = normalize_storage_path(key).lstrip('/')
         if key:
             *bits, end = key.split('/')
-            key = '/'.join(bits + [end.replace('.', self.key_separator)])
+            if not FSStore._is_meta(key):
+                end = end.replace('.', self.key_separator)
+            key = '/'.join(bits + [end])
         return key.lower() if self.normalize_keys else key
 
     def __getitem__(self, key):

--- a/zarr/tests/test_s3.py
+++ b/zarr/tests/test_s3.py
@@ -36,4 +36,4 @@ class TestS3(object):
 
         array_json = conn.Object(bucket, 'test.zarr/array/.zarray').get()
         assert [2,3] == json.loads(array_json["Body"].read())["chunks"]
-        chunk_bytes = conn.Object(bucket, 'test.zarr/array/0.0').get()
+        chunk_bytes = conn.Object(bucket, 'test.zarr/array/0/0').get()

--- a/zarr/tests/test_s3.py
+++ b/zarr/tests/test_s3.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import boto3
+from moto import mock_s3
+
+import json
+
+import zarr
+from zarr.storage import FSStore
+
+class TestS3(object):
+
+    @mock_s3
+    def test_fsstore(self):
+        bucket = "test_fsstore"
+        conn = boto3.resource('s3', region_name='us-east-1')
+        conn.create_bucket(Bucket=bucket)
+
+        store = FSStore(f"s3://{bucket}/test.zarr")
+        group = zarr.group(store=store)
+        array = group.array("array", data=[[1,2,3], [4,5,6]])
+
+        array_json = conn.Object(bucket, 'test.zarr/array/.zarray').get()
+        assert [2,3] == json.loads(array_json["Body"].read())["chunks"]
+        chunk_bytes = conn.Object(bucket, 'test.zarr/array/0.0').get()
+
+    @mock_s3
+    def test_fsstore_nested(self):
+        bucket = "test_fsstore"
+        conn = boto3.resource('s3', region_name='us-east-1')
+        conn.create_bucket(Bucket=bucket)
+
+        store = FSStore(f"s3://{bucket}/test.zarr", key_separator="/")
+        group = zarr.group(store=store)
+        array = group.array("array", data=[[1,2,3], [4,5,6]])
+
+        array_json = conn.Object(bucket, 'test.zarr/array/.zarray').get()
+        assert [2,3] == json.loads(array_json["Body"].read())["chunks"]
+        chunk_bytes = conn.Object(bucket, 'test.zarr/array/0.0').get()


### PR DESCRIPTION
Special case `.zarray`, `.zgroup`, etc. for when a non-default key separator is passed. This also adds `moto` as an optional dev requirement and adds a few methods to a small `test_s3.py`.