### PR TITLE
Mdurant v3 fsspec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,11 @@ extra-dependencies = [
     "pytest-cov",
     "msgpack",
     "lmdb",
+    "s3fs",
     "pytest-asyncio",
-    "moto",
+    "moto[s3]",
+    "flask-cors",
+    "flask",
     "requests",
     "mypy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     'crc32c',
     'zstandard',
     'typing_extensions',
-    'donfig'
+    'donfig',
+    'pytest'
 ]
 dynamic = [
   "version",

--- a/src/zarr/store/remote.py
+++ b/src/zarr/store/remote.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import fsspec
 
 from zarr.abc.store import Store
-from zarr.buffer import Buffer, BufferPrototype
+from zarr.buffer import Buffer, BufferPrototype, default_buffer_prototype
 from zarr.common import OpenMode
 from zarr.store.core import _dereference_path
 
@@ -79,7 +79,7 @@ class RemoteStore(Store):
     async def get(
         self,
         key: str,
-        prototype: BufferPrototype,
+        prototype: BufferPrototype = default_buffer_prototype,
         byte_range: tuple[int | None, int | None] | None = None,
     ) -> Buffer | None:
         path = _dereference_path(self.path, key)

--- a/tests/v3/test_store/test_local.py
+++ b/tests/v3/test_store/test_local.py
@@ -1,46 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from zarr.buffer import Buffer
 from zarr.store.local import LocalStore
-from zarr.store.memory import MemoryStore
 from zarr.testing.store import StoreTests
-
-
-class TestMemoryStore(StoreTests[MemoryStore]):
-    store_cls = MemoryStore
-
-    def set(self, store: MemoryStore, key: str, value: Buffer) -> None:
-        store._store_dict[key] = value
-
-    def get(self, store: MemoryStore, key: str) -> Buffer:
-        return store._store_dict[key]
-
-    @pytest.fixture(scope="function", params=[None, {}])
-    def store_kwargs(self, request) -> dict[str, Any]:
-        return {"store_dict": request.param, "mode": "w"}
-
-    @pytest.fixture(scope="function")
-    def store(self, store_kwargs: dict[str, Any]) -> MemoryStore:
-        return self.store_cls(**store_kwargs)
-
-    def test_store_repr(self, store: MemoryStore) -> None:
-        assert str(store) == f"memory://{id(store._store_dict)}"
-
-    def test_store_supports_writes(self, store: MemoryStore) -> None:
-        assert store.supports_writes
-
-    def test_store_supports_listing(self, store: MemoryStore) -> None:
-        assert store.supports_listing
-
-    def test_store_supports_partial_writes(self, store: MemoryStore) -> None:
-        assert store.supports_partial_writes
-
-    def test_list_prefix(self, store: MemoryStore) -> None:
-        assert True
 
 
 class TestLocalStore(StoreTests[LocalStore]):

--- a/tests/v3/test_store/test_memory.py
+++ b/tests/v3/test_store/test_memory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from zarr.buffer import Buffer
+from zarr.store.memory import MemoryStore
+from zarr.testing.store import StoreTests
+
+
+class TestMemoryStore(StoreTests[MemoryStore]):
+    store_cls = MemoryStore
+
+    def set(self, store: MemoryStore, key: str, value: Buffer) -> None:
+        store._store_dict[key] = value
+
+    def get(self, store: MemoryStore, key: str) -> Buffer:
+        return store._store_dict[key]
+
+    @pytest.fixture(scope="function", params=[None, {}])
+    def store_kwargs(self, request) -> dict[str, str | None | dict[str, Buffer]]:
+        return {"store_dict": request.param, "mode": "w"}
+
+    @pytest.fixture(scope="function")
+    def store(self, store_kwargs: str | None | dict[str, Buffer]) -> MemoryStore:
+        return self.store_cls(**store_kwargs)
+
+    def test_store_repr(self, store: MemoryStore) -> None:
+        assert str(store) == f"memory://{id(store._store_dict)}"
+
+    def test_store_supports_writes(self, store: MemoryStore) -> None:
+        assert store.supports_writes
+
+    def test_store_supports_listing(self, store: MemoryStore) -> None:
+        assert store.supports_listing
+
+    def test_store_supports_partial_writes(self, store: MemoryStore) -> None:
+        assert store.supports_partial_writes
+
+    def test_list_prefix(self, store: MemoryStore) -> None:
+        assert True

--- a/tests/v3/test_store/test_remote.py
+++ b/tests/v3/test_store/test_remote.py
@@ -106,7 +106,7 @@ class TestRemoteStoreS3(StoreTests[RemoteStore]):
         assert True
 
     def test_store_supports_partial_writes(self, store: RemoteStore) -> None:
-        assert True
+        assert False
 
     def test_store_supports_listing(self, store: RemoteStore) -> None:
         assert True

--- a/tests/v3/test_store/test_remote.py
+++ b/tests/v3/test_store/test_remote.py
@@ -43,7 +43,7 @@ def get_boto3_client():
     return session.create_client("s3", endpoint_url=endpoint_uri)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def s3(s3_base):
     client = get_boto3_client()
     client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
@@ -106,8 +106,9 @@ class TestRemoteStoreS3(StoreTests[RemoteStore]):
     def test_store_supports_writes(self, store: RemoteStore) -> None:
         assert True
 
+    @pytest.mark.xfail
     def test_store_supports_partial_writes(self, store: RemoteStore) -> None:
-        assert False
+        raise AssertionError
 
     def test_store_supports_listing(self, store: RemoteStore) -> None:
         assert True


### PR DESCRIPTION
Adds an instance of `StoreTests` parametrized by `RemoteStore`, and refactors the store tests layout

Not mergeable until we figure out why the tests are failing

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
